### PR TITLE
Create routes to manage user's song preferences

### DIFF
--- a/backend/app/api/songs/dislike/route.ts
+++ b/backend/app/api/songs/dislike/route.ts
@@ -1,0 +1,44 @@
+import prisma from '@/lib/prisma';
+import { verifySession } from '@/lib/session';
+import { ErrorResponse } from '@/lib/types';
+import { NextRequest, NextResponse } from 'next/server';
+
+type PutRequest = {
+  trackID: string;
+};
+
+type PutResponse = {
+  success: boolean;
+};
+
+export const PUT = async (
+  req: NextRequest
+): Promise<NextResponse<PutResponse | ErrorResponse>> => {
+  const { trackID }: PutRequest = await req.json();
+
+  const session = await verifySession();
+
+  if (!session.isAuth) {
+    return NextResponse.json({ error: 'Invalid session' });
+  }
+
+  await prisma.song.upsert({
+    where: {
+      trackID,
+    },
+    create: {
+      trackID,
+    },
+    update: {
+      likedBy: {
+        disconnect: {
+          id: session.uid,
+        },
+      },
+    },
+  });
+
+  return NextResponse.json({
+    success: true,
+  });
+};

--- a/backend/app/api/songs/like/route.ts
+++ b/backend/app/api/songs/like/route.ts
@@ -1,0 +1,54 @@
+import prisma from '@/lib/prisma';
+import { verifySession } from '@/lib/session';
+import { ErrorResponse } from '@/lib/types';
+import { NextRequest, NextResponse } from 'next/server';
+
+type PutRequest = {
+  trackID: string;
+};
+
+type PutResponse = {
+  success: boolean;
+};
+
+export const PUT = async (
+  req: NextRequest
+): Promise<NextResponse<PutResponse | ErrorResponse>> => {
+  const { trackID }: PutRequest = await req.json();
+
+  const session = await verifySession();
+
+  // If invalid session, return 400 (bad request)
+  if (!session.isAuth) {
+    return NextResponse.json(
+      {
+        error: 'Invalid session',
+      },
+      { status: 400 }
+    );
+  }
+
+  // Find song in database, create if doesn't exist
+  await prisma.song.upsert({
+    where: {
+      trackID,
+    },
+    create: {
+      trackID,
+      likedBy: {
+        connect: {
+          id: session.uid,
+        },
+      },
+    },
+    update: {
+      likedBy: {
+        connect: {
+          id: session.uid,
+        },
+      },
+    },
+  });
+
+  return NextResponse.json({ success: true });
+};

--- a/backend/app/api/songs/route.ts
+++ b/backend/app/api/songs/route.ts
@@ -1,0 +1,12 @@
+import prisma from '@/lib/prisma';
+import { NextResponse } from 'next/server';
+
+export const GET = async () => {
+  const songs = await prisma.song.findMany({
+    include: {
+      likedBy: true,
+    },
+  });
+
+  return NextResponse.json(songs);
+};


### PR DESCRIPTION
## Changes
- PUT `/api/songs/like`: Like a particular song, updating the preference for the user
- PUT `/api/songs/dislike`: Dislike a particular song, updating the preference for the user
- GET `/api/songs`: Retrieve all songs stored in the database

## Related Issues
- Closes #61 