### PR TITLE
Add routes for fetching and updating genres

### DIFF
--- a/backend/app/api/genre/add/route.ts
+++ b/backend/app/api/genre/add/route.ts
@@ -1,0 +1,51 @@
+import prisma from '@/lib/prisma';
+import { verifySession } from '@/lib/session';
+import { ErrorResponse } from '@/lib/types';
+import { Genre } from '@prisma/client';
+import { NextRequest, NextResponse } from 'next/server';
+
+type PutRequest = {
+  genreName: string;
+};
+
+type PutResponse = {
+  genre: Genre;
+};
+
+export const PUT = async (
+  req: NextRequest
+): Promise<NextResponse<PutResponse | ErrorResponse>> => {
+  const { genreName }: PutRequest = await req.json();
+
+  const session = await verifySession();
+
+  if (!session.isAuth) {
+    return NextResponse.json({ error: 'Invalid session' }, { status: 400 });
+  }
+
+  const genre = await prisma.genre.upsert({
+    where: {
+      value: genreName,
+    },
+    create: {
+      value: genreName,
+      users: {
+        connect: {
+          id: session.uid,
+        },
+      },
+    },
+    update: {
+      users: {
+        connect: {
+          id: session.uid,
+        },
+      },
+    },
+    include: {
+      users: true,
+    },
+  });
+
+  return NextResponse.json({ genre });
+};

--- a/backend/app/api/genre/remove/route.ts
+++ b/backend/app/api/genre/remove/route.ts
@@ -1,0 +1,43 @@
+import prisma from '@/lib/prisma';
+import { verifySession } from '@/lib/session';
+import { ErrorResponse } from '@/lib/types';
+import { Genre } from '@prisma/client';
+import { NextRequest, NextResponse } from 'next/server';
+
+type PutRequest = {
+  genreName: string;
+};
+
+type PutResponse = {
+  genre: Genre;
+};
+
+export const PUT = async (
+  req: NextRequest
+): Promise<NextResponse<PutResponse | ErrorResponse>> => {
+  const { genreName }: PutRequest = await req.json();
+
+  const session = await verifySession();
+
+  if (!session.isAuth) {
+    return NextResponse.json({ error: 'Invalid session' }, { status: 400 });
+  }
+
+  const genre = await prisma.genre.upsert({
+    where: {
+      value: genreName,
+    },
+    create: {
+      value: genreName,
+    },
+    update: {
+      users: {
+        disconnect: {
+          id: session.uid,
+        },
+      },
+    },
+  });
+
+  return NextResponse.json({ genre });
+};

--- a/backend/app/api/genre/route.ts
+++ b/backend/app/api/genre/route.ts
@@ -1,0 +1,8 @@
+import prisma from '@/lib/prisma';
+import { NextResponse } from 'next/server';
+
+export const GET = async () => {
+  const genres = await prisma.genre.findMany();
+
+  return NextResponse.json({ genres });
+};


### PR DESCRIPTION
## Changes
- PUT `/api/genre/add/`: Add a genre to a user's set of preferences
- PUT `/api/genre/remove/`: Remove a genre from a user's set of preferences
- GET `/api/genre/`: Retrieve all genres stored in the database

## Related Issues
- Closes #73 