### PR TITLE
Add seen songs relation to User and Song models

### DIFF
--- a/backend/prisma/migrations/20250202073122_add_seen_to_songs/migration.sql
+++ b/backend/prisma/migrations/20250202073122_add_seen_to_songs/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "_SongSeenBy" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+
+    CONSTRAINT "_SongSeenBy_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "_SongSeenBy_B_index" ON "_SongSeenBy"("B");
+
+-- AddForeignKey
+ALTER TABLE "_SongSeenBy" ADD CONSTRAINT "_SongSeenBy_A_fkey" FOREIGN KEY ("A") REFERENCES "Song"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_SongSeenBy" ADD CONSTRAINT "_SongSeenBy_B_fkey" FOREIGN KEY ("B") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -23,6 +23,7 @@ model User {
   updatedAt DateTime @updatedAt
   preferences Genre[]
   likedSongs Song[]
+  seenSongs Song[] @relation("SongSeenBy")
 }
 
 model Song {
@@ -32,6 +33,7 @@ model Song {
   likedBy User[]
   genreId Int?
   genre Genre? @relation(fields: [genreId], references: [id])
+  seenBy User[] @relation("SongSeenBy")
 } 
 
 


### PR DESCRIPTION
## Changes
- Create a many-to-many relation between `User` and `Song` that represents if a User has seen a particular song (and vice versa)
- This will eventually allow for a better recommendation algorithm

## Related Issues
- Closes #102